### PR TITLE
Fix minor memory issues

### DIFF
--- a/plugin/plugin.cc
+++ b/plugin/plugin.cc
@@ -771,6 +771,7 @@ AEffect* VSTPluginMain(audioMasterCallback audio_master)
   vbe = new vst_bridge_effect;
   if (!vbe)
     goto failed;
+  memset(vbe, 0, sizeof(vst_bridge_effect));
 
   // XXX move to the class description
   vbe->audio_master             = audio_master;
@@ -811,7 +812,7 @@ AEffect* VSTPluginMain(audioMasterCallback audio_master)
   // forward plugin main
   if (!vst_bridge_call_plugin_main(vbe)) {
     close(vbe->socket);
-    free(vbe);
+    delete vbe;
     return NULL;
   }
 
@@ -825,6 +826,6 @@ AEffect* VSTPluginMain(audioMasterCallback audio_master)
   close(fds[1]);
   failed_sockets:
   failed:
-  free(vbe);
+  delete vbe;
   return NULL;
 }


### PR DESCRIPTION
The first line fixes a crash on start in Carla (but there's still another crash later on).
The other two lines properly frees memory created using "new".
